### PR TITLE
Created scripts that execute the code on the Slides

### DIFF
--- a/02-resources-commands.sh
+++ b/02-resources-commands.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -e
+
+cd ~
+
+sudo chef-apply --help
+sudo chef-apply -e "package 'nano'"
+which nano
+sudo chef-apply -e "package 'vim'"
+which vim
+sudo chef-apply -e "package 'emacs'"
+which emacs
+
+echo "file 'hello.txt' do
+  content 'Hello, world!'
+end
+" > ~/hello.rb
+
+sudo chef-apply hello.rb
+cat hello.txt
+
+echo "file 'hello.txt' do
+  content 'Hello, world!'
+  mode '0644'
+  owner 'root'
+  group 'root'
+  action :create
+end
+" > ~/hello.rb
+
+sudo chef-apply hello.rb
+
+echo "package 'nano'
+package 'vim'
+package 'emacs'
+
+package 'tree'
+
+file '/etc/motd' do
+  content 'Property of ...'
+end
+
+" > ~/setup.rb
+
+sudo chef-apply setup.rb

--- a/03-cookbooks-commands.sh
+++ b/03-cookbooks-commands.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -e
+
+cd ~
+echo "package 'nano'
+package 'vim'
+package 'emacs'
+
+package 'tree'
+package 'git'
+
+file '/etc/motd' do
+  content 'Property of ...'
+  mode '0644'
+  owner 'root'
+  group 'root'
+end
+
+
+" > setup.rb
+sudo chef-apply setup.rb
+chef --help
+chef generate --help
+chef generate cookbook --help
+chef generate cookbook workstation
+tree workstation
+cat workstation/metadata.rb
+cat workstation/recipes/default.rb
+mv setup.rb workstation/recipes/setup.rb
+cd workstation
+git init
+git add .
+git status
+git commit -m "Initial workstation cookbook"
+cd ~
+chef generate cookbook apache
+echo "
+package 'httpd'
+
+file '/var/www/html/index.html' do
+  content '<h1>Hello, world!</h1>'
+end
+
+service 'httpd' do
+  action [ :enable, :start ]
+end
+" > ~/apache/recipes/server.rb
+sudo chef-apply apache/recipes/server.rb
+curl localhost
+cd apache
+git init
+git add .
+git commit -m "Initial Apache Cookbook"

--- a/04-chef-client-commands.sh
+++ b/04-chef-client-commands.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+
+cd ~
+mkdir cookbooks
+mv workstation cookbooks
+mv apache cookbooks
+sudo chef-client --local-mode -r "recipe[apache::server]"
+sudo chef-client --local-mode -r "recipe[workstation::setup]"
+sudo chef-client --local-mode \ -r "recipe[apache::server],recipe[workstation::setup]"
+
+echo "#
+# Cookbook Name:: workstation
+# Recipe:: default
+#
+# Copyright (c) 2015 The Authors, All Rights Reserved.
+
+include_recipe 'workstation::setup'
+" > ~/cookbooks/workstation/recipes/default.rb
+
+sudo chef-client --local-mode -r "recipe[workstation]"
+
+echo "#
+# Cookbook Name:: apache
+# Recipe:: default
+#
+# Copyright (c) 2015 The Authors, All Rights Reserved.
+
+include_recipe 'apache::server'
+" > ~/cookbooks/apache/recipes/default.rb
+
+sudo chef-client --local-mode -r "recipe[apache]"
+sudo chef-client --local-mode -r "recipe[apache],recipe[workstation]"

--- a/05-testing-cookbooks-commands.sh
+++ b/05-testing-cookbooks-commands.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -e
+
+cd ~
+kitchen --help
+kitchen help init
+tree cookbooks/workstation -a -I .git
+cat cookbooks/workstation/.kitchen.yml
+cd cookbooks/workstation
+echo "---
+driver:
+  name: docker
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: centos-6.7
+
+suites:
+  - name: default
+    run_list:
+      - recipe[workstation::default]
+    attributes:
+
+" > ~/cookbooks/workstation/.kitchen.yml
+
+kitchen list
+kitchen converge
+
+# apache exercise
+
+echo "---
+driver:
+  name: docker
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: centos-6.7
+
+suites:
+  - name: default
+    run_list:
+      - recipe[apache::default]
+    attributes:
+
+" > ~/cookbooks/apache/.kitchen.yml
+
+cd ~
+cd cookbooks/apache
+kitchen converge
+
+
+# Workstation First Test
+
+echo "require 'spec_helper'
+
+describe 'workstation::default' do
+
+  describe package('tree') do
+    it { should be_installed }
+  end
+
+end
+" > ~/cookbooks/workstation/test/integration/default/serverspec/default_spec.rb
+
+cd ~
+cd cookbooks/workstation
+kitchen verify
+cd ~/cookbooks/workstation
+git add .
+git status
+git commit -m "Added first test for the default recipe"
+
+
+# More workstation Tests
+
+echo "require 'spec_helper'
+
+describe 'workstation::default' do
+
+  describe package('tree') do
+    it { should be_installed }
+  end
+
+  describe package('git') do
+    it { should be_installed }
+  end
+
+  describe file('/etc/motd') do
+    it { should be_owned_by 'root' }
+  end
+
+end
+" > ~/cookbooks/workstation/test/integration/default/serverspec/default_spec.rb
+
+cd ~/cookbooks/workstation
+kitchen verify
+git add .
+git status
+git commit -m "Added additional tests for default recipe"
+
+
+# Apache Tests
+
+cd ~
+cd cookbooks/apache
+echo "require 'spec_helper'
+
+describe 'apache::default' do
+  describe port(80) do
+    it { should be_listening }
+  end
+
+  describe command('curl http://localhost') do
+    its(:stdout) { should match /Hello, world\!/ }
+  end
+end
+" > ~/cookbooks/apache/test/integration/default/serverspec/default_spec.rb
+
+kitchen verify
+cd ~/cookbooks/apache
+git add .
+git status
+git commit -m "Added tests for the default recipe"

--- a/06-details-about-the-system-commands.sh
+++ b/06-details-about-the-system-commands.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -e
+
+hostname -I
+ifconfig
+hostname
+cat /proc/meminfo
+cat /proc/cpuinfo
+
+echo "
+package 'nano'
+package 'vim'
+package 'emacs'
+
+package 'tree'
+package 'git'
+
+file \"/etc/motd\" do
+  content \"Property of ...
+
+  IPADDRESS: HARDCODED VALUE
+  HOSTNAME : HARDCODED VALUE
+  MEMORY   : HARDCODED VALUE
+  CPU      : HARDCODED VALUE
+\"
+  mode '0644'
+  owner 'root'
+  group 'root'
+end
+" > ~/cookbooks/workstation/recipes/setup.rb
+
+cd ~/coobooks/workstation
+kitchen test
+cd ~
+sudo chef-client --local-mode -r "recipe[workstation]"
+cat /etc/motd
+
+#
+
+ohai
+
+echo "
+package 'nano'
+package 'vim'
+package 'emacs'
+
+package 'tree'
+package 'git'
+
+file \"/etc/motd\" do
+  content \"Property of ...
+
+  IPADDRESS: #{node['ipaddress']}
+  HOSTNAME : #{node['hostname']}
+  MEMORY   : #{node['memory']['total']}
+  CPU      : #{node['cpu']['0']['mhz']}
+\"
+  mode '0644'
+  owner 'root'
+  group 'root'
+end
+" > ~/cookbooks/workstation/recipes/setup.rb
+
+cd ~/cookbooks/workstation
+kitchen test
+cd ~
+sudo chef-client --local-mode -r "recipe[workstation]"
+
+
+# Cookbook Versioning
+
+echo "name             'workstation'
+maintainer       'The Authors'
+maintainer_email 'you@example.com'
+license          'all_rights'
+description      'Installs/Configures workstation'
+long_description 'Installs/Configures workstation'
+version          '0.2.0'
+" > ~/cookbooks/workstation/metadata.rb
+
+cd ~/cookbooks/workstation
+git add .
+git status
+git commit -m "Version 0.2.0 - Added Node Details in MOTD"
+
+
+# Apache Exercise
+
+echo "
+package 'httpd'
+
+file '/var/www/html/index.html' do
+  content \"<h1>Hello, world\!</h1>
+  <h2>ipaddress: #{node['ipaddress']}</h2>
+<h2>hostname: #{node['hostname']}</h2>
+\"
+end
+
+service 'httpd' do
+  action [ :enable, :start ]
+end
+" > ~/cookbooks/apache/recipes/server.rb
+
+
+
+cd ~/cookbooks/apache
+kitchen test
+cd ~
+sudo chef-client --local-mode -r "recipe[apache]"
+echo "name             'apache'
+maintainer       'The Authors'
+maintainer_email 'you@example.com'
+license          'all_rights'
+description      'Installs/Configures apache'
+long_description 'Installs/Configures apache'
+version          '0.2.0'
+" > ~/cookbooks/apache/metadata.rb
+
+cd ~/cookbooks/apache
+git add .
+git status
+git commit -m "Version 0.2.0 - Added Node Details in Index Page"

--- a/07-desired-state-and-data-commands.sh
+++ b/07-desired-state-and-data-commands.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -e
+
+#
+chef --help
+chef generate --help
+chef generate template --help
+cd ~
+chef generate templates cookbooks/apache index.html
+tree cookbooks/apache/templates
+
+echo "<html>
+  <body>
+    <h1>Hello, world!</h1>
+    <h2>ipaddress: <%= node['ipaddress'] %></h2>
+    <h2>hostname: <%= node['hostname'] %></h2>
+</body>
+</html>
+" > ~/cookbooks/apache/templates/default/index.html.erb
+
+echo "
+package 'httpd'
+
+template '/var/www/html/index.html' do
+  source 'index.html.erb'
+end
+
+service 'httpd' do
+  action [ :enable, :start ]
+end
+" > ~/cookbooks/apache/recipes/server.rb
+
+$ tree cookbooks/apache/templates/default
+
+# Validate Apache
+
+cd ~/cookbooks/apache
+kitchen test
+cd ~
+sudo chef-client --local-mode -r "recipe[apache]"
+
+echo "name             'apache'
+maintainer       'The Authors'
+maintainer_email 'you@example.com'
+license          'all_rights'
+description      'Installs/Configures apache'
+long_description 'Installs/Configures apache'
+version          '0.2.1'
+" > ~/cookbooks/apache/metadata.rb
+
+cd ~/cookbooks/apache
+git add .
+git status
+git commit -m "Changed file resource to template resource and defined a template"
+
+
+# Workstation Exercise
+
+cd ~
+chef generate template cookbooks/workstation motd
+echo "Property of ...
+
+  IPADDRESS: <%= node[\"ipaddress\"] %>
+  HOSTNAME : <%= node[\"hostname\"] %>
+  MEMORY   : <%= node[\"memory\"][\"total\"] %>
+  CPU      : <%= node[\"cpu\"][\"0\"][\"mhz\"] %>
+" > ~/cookbooks/workstation/templates/default/motd.erb
+
+echo "package 'nano'
+package 'vim'
+package 'emacs'
+
+package 'tree'
+package 'git'
+
+template '/etc/motd' do
+  source 'motd.erb'
+  mode '0644'
+  owner 'root'
+  group 'root'
+end
+" > ~/cookbooks/workstation/recipes/setup.rb
+
+cd ~/cookbooks/workstation
+kitchen test
+cd ~
+sudo chef-client --local-mode -r "recipe[workstation]"

--- a/10-community-cookbooks-commands.sh
+++ b/10-community-cookbooks-commands.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -e
+
+#
+# This script turns off apache and then proceeds to generate
+# a wrapper cookbook like the learner does. It does so on the remote
+# instance so it is not exactly the same as what the learner experiences
+# but it at least ensures that the instance will work with the contents
+# of the cookbook
+#
+
+# DISABLE APACHE
+sudo service httpd stop
+
+cd ~
+chef generate cookbook cookbooks/myhaproxy
+
+echo "name             'myhaproxy'
+maintainer       'The Authors'
+maintainer_email 'you@example.com'
+license          'all_rights'
+description      'Installs/Configures myhaproxy'
+long_description 'Installs/Configures myhaproxy'
+version          '0.1.0'
+
+depends 'haproxy', '~> 1.6.6'
+
+" > ~/cookbooks/myhaproxy/metadata.rb
+
+echo "
+
+node.default['haproxy']['members'] = [{
+    'hostname' => 'ec2-52-8-71-11.us-west-1.compute.amazonaws.com',
+    'ipaddress' => '52.8.71.11',
+    'port' => 80,
+    'ssl_port' => 80
+  }]
+
+include_recipe 'haproxy::default'
+
+" > ~/cookbooks/myhaproxy/recipes/default.rb
+
+cd ~/cookbooks/myhaproxy
+berks install
+# berks upload
+cd ~
+cp -R ~/.berkshelf/cookbooks/build-essential-2.2.4 cookbooks/build-essential
+cp -R ~/.berkshelf/cookbooks/cpu-0.2.0 cookbooks/cpu
+cp -R ~/.berkshelf/cookbooks/haproxy-1.6.6 cookbooks/haproxy
+
+sudo chef-client --local-mode -r "recipe[myhaproxy]"


### PR DESCRIPTION
Created scripts that execute the code on the Slides

We talked about not having a great way to verify that our instances worked with the version of the     ChefDK. We also have a hard time verifying if the code in the slides works. It is also sometimes       useful to work through a problem on your own machine but you are too far behind to catch up.

These script files are tied to each section and will complete the exercises in each of their sections.

Running these will:

* Verify that the instance works with the code within the slide
* Allow an instructor or attendee to catch up

Introducing these scripts outside of the slide means that they are very likely to get out of date. I   think they still provide value.